### PR TITLE
Deactivate transpilation to es5. r=azasypkin

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
-  "presets": ["es2015", "react"],
+  "presets": ["react"],
   "plugins": ["transform-es2015-modules-amd"]
 }


### PR DESCRIPTION
We're targeting the latest versions of Fennec and Chrome Android for now, so we can safely deactivate the transpilation to es5.
Babel is used for es2015 modules and JSX conversion. In the future, we'll activate missing es2015 features as we support a wider range of browsers.

@azasypkin: do you approve the above?