### PR TITLE
Add a link to a PNG icon in html page

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -22,6 +22,7 @@
 <link rel="stylesheet" href="css/vendors/philips-hue.css">
 <link rel="stylesheet" href="css/app.css">
 <link rel="manifest" href="manifest.webmanifest">
+<link rel="icon" href="img/icons/512.png" sizes="512x512">
 <link rel="icon" href="img/icon.svg" sizes="any" type="image/svg+xml">
 <title>Project Link</title>
 <script defer src="cordova.js"></script>


### PR DESCRIPTION
It turns out Fennec doesn't like SVG in the `<link ref="icon">` tags.