### PR TITLE
Add a 32px icon to html page

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -22,6 +22,7 @@
 <link rel="stylesheet" href="css/vendors/philips-hue.css">
 <link rel="stylesheet" href="css/app.css">
 <link rel="manifest" href="manifest.webmanifest">
+<link rel="icon" href="img/icons/32.png" sizes="32x32">
 <link rel="icon" href="img/icons/512.png" sizes="512x512">
 <link rel="icon" href="img/icon.svg" sizes="any" type="image/svg+xml">
 <title>Project Link</title>


### PR DESCRIPTION
Even a 512px PNG is not good enough for Fennec nightly to use in the bookmarks or on the home screen.