### PR TITLE
Upgrade selenium to 2.53

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ addons:
 install:
   - "sh -e /etc/init.d/xvfb start"
   - "export DISPLAY=:99.0"
-  - "wget http://selenium-release.storage.googleapis.com/2.50/selenium-server-standalone-2.50.1.jar"
-  - "java -jar selenium-server-standalone-2.50.1.jar > /dev/null &"
+  - "wget http://selenium-release.storage.googleapis.com/2.53/selenium-server-standalone-2.53.0.jar"
+  - "java -jar selenium-server-standalone-2.53.1.jar > /dev/null &"
   - npm install
 
 script:

--- a/README.md
+++ b/README.md
@@ -83,4 +83,4 @@ Steps (to be scripted soon):
 1. Clone [foxbox](https://github.com/fxbox/foxbox/)
 2. Run it with `cargo run`
 3. With a browser, perform the first time setup by going to [http://localhost:3000](http://localhost:3000/)
-4. Run `npm test-e2e`
+4. Run `gulp test-e2e`

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "requirejs": "^2.2.0",
     "run-sequence": "^1.1.5",
     "rxjs": "^5.0.0-beta.4",
-    "selenium-webdriver": "^2.52.0",
+    "selenium-webdriver": "^2.53.1",
     "sinon": "^1.17.3",
     "sinon-chai": "^2.8.0"
   }


### PR DESCRIPTION
Similarly to https://github.com/fxbox/foxbox/pull/313, we encountered issue while running the tests locally. Upgrading to Selenium to 2.53 enables us to use marionette-server as a backend and fixed the tests locally, for @isabelrios and myself.

r? @isabelrios 