### PR TITLE
When using the indexedDB, stop wrapping services info in data object. r=azasypkin

### DIFF
--- a/app/js/lib/foxbox/db.js
+++ b/app/js/lib/foxbox/db.js
@@ -65,7 +65,6 @@ export default class Db {
     if (fromVersion < 1) {
       let store = db.createObjectStore(DB_SERVICE_STORE, { keyPath: 'id' });
       store.createIndex('id', 'id', { unique: true });
-      store.createIndex('type', 'type', { unique: false });
 
       store = db.createObjectStore(DB_TAG_STORE, {
         keyPath: 'id',
@@ -157,16 +156,11 @@ export default class Db {
 
   [p.set](store, data) {
     return new Promise((resolve, reject) => {
-      const id = data.id;
       const txn = this[p.db].transaction([store], 'readwrite');
       txn.oncomplete = resolve;
       txn.onerror = reject;
       try {
-        if (id) {
-          txn.objectStore(store).put({ id, data });
-        } else {
-          txn.objectStore(store).put({ data });
-        }
+        txn.objectStore(store).put(data);
       } catch (error) {
         console.error(`Error putting data in ${DB_NAME}:`, error);
         resolve();

--- a/app/js/lib/foxbox/foxbox.js
+++ b/app/js/lib/foxbox/foxbox.js
@@ -418,7 +418,7 @@ export default class Foxbox extends Service {
   getServices() {
     return this[p.db].getServices()
       .then((services) => services.map(
-        (service) => this[p.getServiceInstance](service.data)
+        (service) => this[p.getServiceInstance](service)
       ));
   }
 
@@ -430,7 +430,7 @@ export default class Foxbox extends Service {
   getService() {
     // Get data from the DB so we get the attributes, the state and the tags.
     return this[p.db].getService.apply(this[p.db], arguments)
-      .then((service) => this[p.getServiceInstance](service.data));
+      .then((service) => this[p.getServiceInstance](service));
   }
 
   setService() {

--- a/app/js/views/services/default.jsx
+++ b/app/js/views/services/default.jsx
@@ -44,8 +44,7 @@ export default class Service extends React.Component {
     this.foxbox.getTags()
       .then((tags) => {
         tags.forEach((tag) => {
-          tag.data.checked = !!(this.state.data &&
-            this.state.data.includes(tag.id));
+          tag.checked = !!(this.state.data && this.state.data.includes(tag.id));
         });
 
         this.setState({ tags });

--- a/app/js/views/services/light.jsx
+++ b/app/js/views/services/light.jsx
@@ -44,8 +44,7 @@ export default class LightService extends React.Component {
     this.foxbox.getTags()
       .then((tags) => {
         tags.forEach((tag) => {
-          tag.data.checked = !!(this.state.data &&
-            this.state.data.includes(tag.id));
+          tag.checked = !!(this.state.data && this.state.data.includes(tag.id));
         });
 
         this.setState({ tags });

--- a/app/js/views/tag-item.jsx
+++ b/app/js/views/tag-item.jsx
@@ -18,18 +18,18 @@ export default class TagItem extends React.Component {
 
     this.foxbox.getService(this.props.serviceId)
       .then((service) => {
-        if (!service.data.tags) {
-          service.data.tags = [];
+        if (!service.tags) {
+          service.tags = [];
         }
 
-        service.data.tags = service.data.tags.filter(
+        service.tags = service.tags.filter(
           (tag) => tag !== this.props.id
         );
         if (checked) {
-          service.data.tags.push(this.props.id);
+          service.tags.push(this.props.id);
         }
 
-        this.foxbox.setService(service.data);
+        this.foxbox.setService(service);
       })
       .catch((error) => {
         this.setState({ checked: !checked }); // Revert back to original state.

--- a/app/js/views/tag-list.jsx
+++ b/app/js/views/tag-list.jsx
@@ -14,8 +14,8 @@ export default class TagList extends React.Component {
         <TagItem
           key={tag.id}
           id={tag.id}
-          name={tag.data.name}
-          checked={tag.data.checked}
+          name={tag.name}
+          checked={tag.checked}
           serviceId={this.props.serviceId}
           foxbox={this.foxbox}/>
       )


### PR DESCRIPTION
Wrapping info in object (e.g. `{ id, data }`) when interacting with the indexedDB only caused confusion. That makes the signature of `foxbox#getServices()` and `foxbox#[p.fetchServices]()` the same.

@azasypkin: What do you think?