### PR TITLE
Add a command to generate documentation. r=azasypkin

### DIFF
--- a/esdoc.json
+++ b/esdoc.json
@@ -1,0 +1,9 @@
+{
+  "source": "./app/js/lib/foxbox",
+  "destination": "./doc",
+  "title": "Project Link web app",
+  "test": {
+    "type": "mocha",
+    "source": "./tests"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "build": "gulp build",
     "test": "gulp test",
+    "doc": "rm -rf doc && esdoc -c esdoc.json",
     "generate-icons": "inkscape -e app/img/icons/128.png -w 128 app/img/icon.svg;inkscape -e app/img/icons/512.png -w 512 app/img/icon.svg;inkscape -e app/img/icons/60.png -w 60 app/img/icon.svg;inkscape -e app/img/icons/16.png -w 16 app/img/icon.svg;inkscape -e app/img/icons/32.png -w 32 app/img/icon.svg;inkscape -e app/img/icons/48.png -w 48 app/img/icon.svg;inkscape -e app/img/icons/64.png -w 64 app/img/icon.svg;inkscape -e app/img/icons/90.png -w 90 app/img/icon.svg;inkscape -e app/img/icons/144.png -w 144 app/img/icon.svg;inkscape -e app/img/icons/256.png -w 256 app/img/icon.svg;inkscape -e app/img/icons/336.png -w 336 app/img/icon.svg;inkscape -e app/favicon.ico -w 32 app/img/icon.svg"
   },
   "keywords": [
@@ -22,6 +23,7 @@
     "babel-plugin-transform-es2015-modules-amd": "^6.6.5",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
+    "esdoc": "^0.4.7",
     "fxos-mvc": "fxos-eng/mvc#master",
     "gulp": "^3.9.1",
     "react": "^15.0.1",

--- a/tests/unit/lib/foxbox/api_test.js
+++ b/tests/unit/lib/foxbox/api_test.js
@@ -1,12 +1,13 @@
 import { waitForNextMacroTask } from '../../test-utils';
 import API from 'js/lib/foxbox/api';
 
-describe('API >', function () {
+/** @test {API} */
+describe('API >', function() {
   let netStub, settingsStub, api;
 
   const testBlob = new Blob([], { type: 'image/jpeg' });
 
-  beforeEach(function () {
+  beforeEach(function() {
     this.sinon = sinon.sandbox.create();
     this.sinon.useFakeTimers();
 
@@ -36,6 +37,7 @@ describe('API >', function () {
   });
 
   describe('when online and authenticated >', function() {
+    /** @test {API#get} */
     describe('get >', function() {
       it('throws if wrong path is used', function(done) {
         const noArgsPromise = api.get()
@@ -80,6 +82,7 @@ describe('API >', function () {
       });
     });
 
+    /** @test {API#post} */
     describe('post >', function() {
       it('throws if wrong path is used', function(done) {
         const noArgsPromise = api.post()
@@ -126,6 +129,7 @@ describe('API >', function () {
       });
     });
 
+    /** @test {API#put} */
     describe('put >', function() {
       it('throws if wrong path is used', function(done) {
         const noArgsPromise = api.put()
@@ -172,6 +176,7 @@ describe('API >', function () {
       });
     });
 
+    /** @test {API#blob} */
     describe('blob >', function() {
       it('throws if wrong path is used', function(done) {
         const noArgsPromise = api.blob()
@@ -238,6 +243,7 @@ describe('API >', function () {
       });
     });
 
+    /** @test {API#watch} */
     describe('watch >', function() {
       const testGetterId1 = 'getter-id-1';
       const testGetterId2 = 'getter-id-2';
@@ -396,6 +402,7 @@ describe('API >', function () {
       });
     });
 
+    /** @test {API#unwatch} */
     describe('unwatch >', function() {
       const testGetterId1 = 'getter-id-1';
       const testGetterId2 = 'getter-id-2';
@@ -498,6 +505,7 @@ describe('API >', function () {
       settingsStub.session = '';
     });
 
+    /** @test {API#get} */
     it('"get" correctly waits for the api readiness', function(done) {
       const resourcePromise = api.get('resource');
 
@@ -529,6 +537,7 @@ describe('API >', function () {
         .then(done, done);
     });
 
+    /** @test {API#post} */
     it('"post" correctly waits for the api readiness', function(done) {
       const resourcePromise = api.post(
         'resource-post', { parameters: 'parameters' }
@@ -564,6 +573,7 @@ describe('API >', function () {
         .then(done, done);
     });
 
+    /** @test {API#put} */
     it('"put" correctly waits for the api readiness', function(done) {
       const resourcePromise = api.put(
         'resource-put', { parameters: 'parameters' }
@@ -599,6 +609,7 @@ describe('API >', function () {
         .then(done, done);
     });
 
+    /** @test {API#blob} */
     it('"blob" correctly waits for the api readiness', function(done) {
       const resourcePromise = api.blob(
         'resource-blob-put',
@@ -637,6 +648,7 @@ describe('API >', function () {
         .then(done, done);
     });
 
+    /** @test {API#watch} */
     it('"watch" correctly waits for the api readiness', function(done) {
       const getterToWatchId = 'getter-id-1';
       const onWatchStub = sinon.stub();

--- a/tests/unit/lib/foxbox/common/defer_test.js
+++ b/tests/unit/lib/foxbox/common/defer_test.js
@@ -1,9 +1,10 @@
 import Defer from 'js/lib/foxbox/common/defer';
 
-describe('Defer >', function () {
+/** @test {Defer} */
+describe('Defer >', function() {
   let defer, onResolve, onReject;
 
-  beforeEach(function () {
+  beforeEach(function() {
     defer = new Defer();
 
     onResolve = sinon.stub();
@@ -12,6 +13,7 @@ describe('Defer >', function () {
     defer.promise.then(onResolve, onReject);
   });
 
+  /** @test {Defer#resolve} */
   it('resolve', function(done) {
     Promise.resolve()
       .then(() => {
@@ -30,6 +32,7 @@ describe('Defer >', function () {
       .then(done, done);
   });
 
+  /** @test {Defer#reject} */
   it('reject', function(done) {
     Promise.resolve()
       .then(() => {

--- a/tests/unit/lib/foxbox/common/event-dispatcher_test.js
+++ b/tests/unit/lib/foxbox/common/event-dispatcher_test.js
@@ -1,31 +1,34 @@
 import EventDispatcher from 'js/lib/foxbox/common/event-dispatcher';
 
-describe('EventDispatcher >', function () {
+/** @test {EventDispatcher} */
+describe('EventDispatcher >', function() {
   const allowedEvents = ['allowed-event-1', 'allowed-event-2'];
 
   let eventTarget = null,
     restrictedEventTarget = null;
 
-  beforeEach(function () {
+  beforeEach(function() {
     eventTarget = new EventDispatcher();
     restrictedEventTarget = new EventDispatcher(allowedEvents);
   });
 
-  afterEach(function () {
+  afterEach(function() {
     eventTarget.offAll();
     restrictedEventTarget.offAll();
   });
 
-  describe('constructor >', function () {
-    it('throws if invalid array is passed for allowedEvents', function () {
+  /** @test {EventDispatcher#constructor} */
+  describe('constructor >', function() {
+    it('throws if invalid array is passed for allowedEvents', function() {
       assert.throws(() => new EventDispatcher(null));
       assert.throws(() => new EventDispatcher('event'));
       assert.throws(() => new EventDispatcher(new Set()));
     });
   });
 
-  describe('on >', function () {
-    it('throws if event name is not valid string', function () {
+  /** @test {EventDispatcher#on} */
+  describe('on >', function() {
+    it('throws if event name is not valid string', function() {
       assert.throws(() => eventTarget.on());
       assert.throws(() => eventTarget.on('', () => {
       }));
@@ -33,13 +36,13 @@ describe('EventDispatcher >', function () {
       }));
     });
 
-    it('throws if handler is not function', function () {
+    it('throws if handler is not function', function() {
       assert.throws(() => eventTarget.on('event'));
       assert.throws(() => eventTarget.on('event', null));
       assert.throws(() => eventTarget.on('event', {}));
     });
 
-    it('successfully registers handler', function () {
+    it('successfully registers handler', function() {
       const expectedHandler = sinon.stub();
       const unexpectedHandler = sinon.stub();
 
@@ -54,7 +57,7 @@ describe('EventDispatcher >', function () {
       sinon.assert.notCalled(unexpectedHandler);
     });
 
-    it('successfully registers multiple handlers', function () {
+    it('successfully registers multiple handlers', function() {
       const expectedHandler1 = sinon.stub();
       const expectedHandler2 = sinon.stub();
       const unexpectedHandler = sinon.stub();
@@ -71,12 +74,12 @@ describe('EventDispatcher >', function () {
       sinon.assert.callOrder(expectedHandler1, expectedHandler2);
     });
 
-    describe('with allowed events >', function () {
-      it('throws if event name is not allowed', function () {
+    describe('with allowed events >', function() {
+      it('throws if event name is not allowed', function() {
         assert.throws(() => restrictedEventTarget.on('event'));
       });
 
-      it('successfully registers handler for allowed event', function () {
+      it('successfully registers handler for allowed event', function() {
         const expectedHandler = sinon.stub();
         const unexpectedHandler = sinon.stub();
 
@@ -93,20 +96,21 @@ describe('EventDispatcher >', function () {
     });
   });
 
-  describe('once >', function () {
-    it('throws if event name is not valid string', function () {
+  /** @test {EventDispatcher#once} */
+  describe('once >', function() {
+    it('throws if event name is not valid string', function() {
       assert.throws(() => eventTarget.once());
       assert.throws(() => eventTarget.once('', () => {}));
       assert.throws(() => eventTarget.once(null, () => {}));
     });
 
-    it('throws if handler is not function', function () {
+    it('throws if handler is not function', function() {
       assert.throws(() => eventTarget.once('event'));
       assert.throws(() => eventTarget.once('event', null));
       assert.throws(() => eventTarget.once('event', {}));
     });
 
-    it('successfully registers handler', function () {
+    it('successfully registers handler', function() {
       const expectedHandler = sinon.stub();
       const unexpectedHandler = sinon.stub();
 
@@ -122,7 +126,7 @@ describe('EventDispatcher >', function () {
       sinon.assert.notCalled(unexpectedHandler);
     });
 
-    it('successfully registers multiple handlers', function () {
+    it('successfully registers multiple handlers', function() {
       const expectedHandler1 = sinon.stub();
       const expectedHandler2 = sinon.stub();
       const unexpectedHandler = sinon.stub();
@@ -139,7 +143,7 @@ describe('EventDispatcher >', function () {
       sinon.assert.callOrder(expectedHandler1, expectedHandler2);
     });
 
-    it('correctly passes parameters', function () {
+    it('correctly passes parameters', function() {
       const handler = sinon.stub();
 
       eventTarget.once('event', handler);
@@ -149,18 +153,18 @@ describe('EventDispatcher >', function () {
       sinon.assert.calledWithExactly(handler, undefined);
 
       eventTarget.once('event', handler);
-      eventTarget.emit('event', {a: 'b'});
+      eventTarget.emit('event', { a: 'b' });
 
       sinon.assert.calledTwice(handler);
-      sinon.assert.calledWithExactly(handler, {a: 'b'});
+      sinon.assert.calledWithExactly(handler, { a: 'b' });
     });
 
-    describe('with allowed events >', function () {
-      it('throws if event name is not allowed', function () {
+    describe('with allowed events >', function() {
+      it('throws if event name is not allowed', function() {
         assert.throws(() => restrictedEventTarget.once('event'));
       });
 
-      it('successfully registers handler for allowed event', function () {
+      it('successfully registers handler for allowed event', function() {
         const expectedHandler = sinon.stub();
         const unexpectedHandler = sinon.stub();
 
@@ -178,6 +182,7 @@ describe('EventDispatcher >', function () {
     });
   });
 
+  /** @test {EventDispatcher#off} */
   describe('off >', function() {
     it('throws if event name is not valid string', function() {
       assert.throws(() => eventTarget.off());
@@ -257,6 +262,7 @@ describe('EventDispatcher >', function () {
     });
   });
 
+  /** @test {EventDispatcher#offAll} */
   describe('offAll >', function() {
     it('throws if event name is not valid string', function() {
       assert.throws(() => eventTarget.offAll(''));
@@ -337,6 +343,7 @@ describe('EventDispatcher >', function () {
     });
   });
 
+  /** @test {EventDispatcher#emit} */
   describe('emit >', function() {
     it('throws if event name is not valid string', function() {
       assert.throws(() => eventTarget.emit());
@@ -422,6 +429,7 @@ describe('EventDispatcher >', function () {
     });
   });
 
+  /** @test {EventDispatcher#hasListeners} */
   describe('hasListeners >', function() {
     it('throws if event name is not valid string', function() {
       assert.throws(() => eventTarget.hasListeners());

--- a/tests/unit/lib/foxbox/common/sequential-timer_test.js
+++ b/tests/unit/lib/foxbox/common/sequential-timer_test.js
@@ -3,7 +3,8 @@ import { waitForNextMacroTask } from '../../../test-utils';
 import Defer from 'js/lib/foxbox/common/defer';
 import SequentialTimer from 'js/lib/foxbox/common/sequential-timer';
 
-describe('SequentialTimer >', function () {
+/** @test {SequentialTimer} */
+describe('SequentialTimer >', function() {
   const DEFAULT_INTERVAL = 2000;
 
   let timer;
@@ -23,6 +24,7 @@ describe('SequentialTimer >', function () {
     this.sinon = null;
   });
 
+  /** @test {SequentialTimer#start} */
   describe('start >', function() {
     it('throws if "onTick" is not provided or not a function', function() {
       assert.throws(() => timer.start());
@@ -128,6 +130,7 @@ describe('SequentialTimer >', function () {
     });
   });
 
+  /** @test {SequentialTimer#stop} */
   describe('stop >', function() {
     beforeEach(function() {
       timer.start(onTick);
@@ -175,6 +178,7 @@ describe('SequentialTimer >', function () {
     });
   });
 
+  /** @test {SequentialTimer#interval} */
   describe('interval >', function() {
     it('is correctly set by default', function() {
       assert.equal(timer.interval, DEFAULT_INTERVAL);

--- a/tests/unit/lib/foxbox/foxbox_test.js
+++ b/tests/unit/lib/foxbox/foxbox_test.js
@@ -1,5 +1,6 @@
 import Foxbox from 'js/lib/foxbox/foxbox';
 
+/** @test {Foxbox} */
 describe('Foxbox >', function() {
   const singleBox = [{
     public_ip: '1.1.1.1',
@@ -45,6 +46,7 @@ describe('Foxbox >', function() {
     });
   });
 
+  /** @test {Foxbox#constructor} */
   describe('constructor >', function() {
     it('exposes a non extensible object', function() {
       assert.isObject(foxbox);
@@ -68,6 +70,7 @@ describe('Foxbox >', function() {
     });
   });
 
+  /** @test {Foxbox#init} */
   describe('init >', function() {
     describe('exposes an array of boxes', function() {
       it('in single box mode', function(done) {

--- a/tests/unit/lib/foxbox/services_test.js
+++ b/tests/unit/lib/foxbox/services_test.js
@@ -5,7 +5,8 @@ import BaseService from 'js/lib/foxbox/services/base';
 import DoorLockService from 'js/lib/foxbox/services/door-lock';
 import MotionSensorService from 'js/lib/foxbox/services/motion-sensor';
 
-describe('Services >', function () {
+/** @test {Services} */
+describe('Services >', function() {
   let services, dbStub, apiStub, settingsStub;
 
   const dbServices = [
@@ -34,7 +35,7 @@ describe('Services >', function () {
     },
   ];
 
-  beforeEach(function () {
+  beforeEach(function() {
     dbStub = sinon.stub({
       getServices: () => {},
       setService: () => {},
@@ -49,6 +50,7 @@ describe('Services >', function () {
     services = new Services(dbStub, apiStub, settingsStub);
   });
 
+  /** @test {Services#getAll} */
   it('"getAll" returns all currently cached services', function(done) {
     services.getAll()
       .then((services) => {
@@ -72,6 +74,7 @@ describe('Services >', function () {
       .then(done, done);
   });
 
+  /** @test {Services#get} */
   it('"get" returns service by its id', function(done) {
     Promise.all([services.get('id-one'), services.get('id-two')])
       .then(([baseService, motionSensorService]) => {
@@ -91,6 +94,7 @@ describe('Services >', function () {
       .then(done, done);
   });
 
+  /** @test {Services#togglePolling} */
   describe('polling >', function() {
     const doorLockServiceRaw = {
       id: 'id-three',


### PR DESCRIPTION
This patch adds a command to generate documentation from the source code.
Open questions:
* Shall we host the generated HTML files somewhere? If so where?
* Shall we commit the generated files? Possibly via a precommit hook.
* The optional parameters syntax used by Closure Compiler is not supported by esdoc. Shall we write an esdoc plug-in for that?

What do you think @azasypkin?