### PR TITLE
Compatibility with iOS. r=azasypkin

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,18 @@
 {
-  "presets": ["react"],
-  "plugins": ["transform-es2015-modules-amd"]
+  "presets": [
+    "react"
+  ],
+  "plugins": [
+    "transform-es2015-modules-amd",
+    "check-es2015-constants",
+    "transform-es2015-block-scoping",
+    "transform-es2015-arrow-functions",
+    "transform-es2015-parameters",
+    [
+      "transform-es2015-classes",
+      {
+        "loose": true
+      }
+    ]
+  ]
 }

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ The following browsers are actively supported:
 
 * Firefox Nightly for Android
 * Chrome Beta for Android
+* Safari for iOS 9
 
 ## Prerequisites
 
@@ -36,24 +37,27 @@ $ npm install
 $ gulp
 ```
 
-Then point your browser to [https://localhost:8000](https://localhost:8000/) and accept security exception for self-signed
+Then point your browser to [https://localhost:8000](https://localhost:8000/) and
+accept security exception for self-signed
 development certificate.
 
-By default app is served via `https` using self-signed certificate from `certs` folder. Certificate is valid for ~100
-years and generated with the following command:
+By default app is served via `https` using self-signed certificate from `certs`
+folder. Certificate is valid for ~100 years and generated with the following
+command:
 
 ```bash
 $ openssl req -x509 -newkey rsa:2048 -keyout key.pem -out cert.pem -days 36500 -nodes
 ```
 
-In case custom certificate is required you can either override respective files in `certs` folder or change certificate
-and private key paths in `webserver` gulp task in `gulpfile.js`.
+In case custom certificate is required you can either override respective files
+in `certs` folder or change certificate and private key paths in `webserver`
+gulp task in `gulpfile.js`.
 
-Even though it's not recommended sometimes you may want to switch to `http`, for that purpose just comment out `https`
-config property in `webserver` gulp task in `gulpfile.js`. Check out official [gulp-webserver module page](https://www.npmjs.com/package/gulp-webserver)
-for possible options as well. And don't forget to flip it back while running integration tests as they will still assume
-that app is run via `https`.
-
+Even though it's not recommended sometimes you may want to switch to `http`, for
+that purpose just comment out `https` config property in `webserver` gulp task
+in `gulpfile.js`. Check out official [gulp-webserver module page](https://www.npmjs.com/package/gulp-webserver)
+for possible options as well. And don't forget to flip it back while running
+integration tests as they will still assume that app is run via `https`.
 
 Note: The app is built in the `dist/app` folder.
 
@@ -61,17 +65,18 @@ Note: The app is built in the `dist/app` folder.
 
 ### Supported browsers
 
-|         | Firefox 46   | Firefox Nightly 49    | Chrome 50       | Chrome Canary 51   | Opera           |
-| ------- | ------------ | --------------------- | --------------- | ------------------ | --------------- |
-|   OSX   |   Working    |       Working         | Coming soon     | Coming soon        | Coming soon     |
-|  Linux  |   Working    |       Working         | Coming soon     | Coming soon        | Coming soon     |
-| Windows |  Not tested  |      Not tested       | Not tested      | Not tested         | Not tested      |
-| Android | Not working  |      Coming soon      | Coming soon     | Coming soon        | Coming soon     |
+|         | Firefox 46  | Firefox Nightly 49 | Chrome 50       | Chrome Canary 51   | Opera           | Safari     |
+| ------- | ----------- | ------------------ | --------------- | ------------------ | --------------- | ---------- |
+|   OSX   |   Working   |      Working       | Coming soon     | Coming soon        | Coming soon     | Not tested |
+|  Linux  |   Working   |      Working       | Coming soon     | Coming soon        | Coming soon     |            |
+| Windows |  Not tested |     Not tested     | Not tested      | Not tested         | Not tested      |            |
+| Android | Not working |     Coming soon    | Coming soon     | Coming soon        | Coming soon     |            |
+|   iOS   |             |                    |                 |                    |                 | Not tested |
 
 ### Prerequisites
 
 There are a couple of steps that you must do in order to have push notifications
- working. As they rely on Service Workers, make sure you follow the next steps:
+working. As they rely on Service Workers, make sure you follow the next steps:
 
 * Push Notification will need **HTTPS everywhere**, so be sure your `foxbox` is
 running over SSL.
@@ -81,14 +86,16 @@ certificate.
 the self self-signed certificate.
 
 ### Tips and tricks
+
 * To start over with a new test, clean the web push database in the foxbox:
 ```rm -rf $HOME/.local/share/foxbox/webpush.sqlite``` and start a Firefox
 instance with a new profile ```<path to firefox bin> --profile /tmp/<random>```.
 * If you want to perform multiple tries with same profile try to use a service
-like `xip.io`. Where you can have different names pointing to your local ip like `https://myname.<my local ip>.xip.io:8000` for using this, remember to launch
+like `xip.io`. Where you can have different names pointing to your local ip like
+`https://myname.<my local ip>.xip.io:8000` for using this, remember to launch
 your gulp task like `HOST=<my local ip> gulp`. Doing this you are creating
 different origins, which will make you receive multiple notifications (as many
-  as app origin registered).
+as app origin registered).
 
 ## Tests
 

--- a/app/js/lib/foxbox/foxbox.js
+++ b/app/js/lib/foxbox/foxbox.js
@@ -217,17 +217,19 @@ export default class Foxbox extends Service {
     }
 
     const url = new URL(location.href);
-    if (!url.searchParams.has('session_token')) {
+    const searchParams = new URLSearchParams(url.search.substring(1));
+    if (!searchParams.has('session_token')) {
       return Promise.resolve();
     }
 
     // There is a session token in the URL, let's remember it.
     // @todo Find a better way to handle URL escape.
-    this[p.settings].session = url.searchParams.get('session_token')
+    this[p.settings].session = searchParams.get('session_token')
       .replace(/ /g, '+');
 
     // Remove the session param from the current location.
-    url.searchParams.delete('session_token');
+    searchParams.delete('session_token');
+    url.search = searchParams;
     location.replace(url.href);
 
     // Returning rejected promise here the promise chain.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -50,6 +50,8 @@ gulp.task('lint', function() {
 gulp.task('loader-polyfill', function() {
   return gulp.src([
       './node_modules/alameda/alameda.js',
+      './node_modules/whatwg-fetch/fetch.js',
+      './node_modules/url-search-params/build/url-search-params.max.js',
       `${APP_ROOT}js/bootstrap.js`,
     ])
     .pipe(concat('initapp.js'))

--- a/package.json
+++ b/package.json
@@ -20,14 +20,21 @@
   "license": "MPL2",
   "dependencies": {
     "alameda": "^1.0.0",
+    "babel-plugin-check-es2015-constants": "^6.8.0",
+    "babel-plugin-transform-es2015-arrow-functions": "^6.8.0",
+    "babel-plugin-transform-es2015-block-scoping": "^6.9.0",
+    "babel-plugin-transform-es2015-classes": "^6.9.0",
     "babel-plugin-transform-es2015-modules-amd": "^6.8.0",
+    "babel-plugin-transform-es2015-parameters": "^6.9.0",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-react": "^6.5.0",
     "esdoc": "^0.4.7",
     "fxos-mvc": "fxos-eng/mvc#master",
     "gulp": "^3.9.1",
     "react": "^15.0.2",
-    "react-dom": "^15.0.2"
+    "react-dom": "^15.0.2",
+    "url-search-params": "^0.5.0",
+    "whatwg-fetch": "^1.0.0"
   },
   "devDependencies": {
     "babel-eslint": "^6.0.4",


### PR DESCRIPTION
Adding support for Safari on iOS 9.3.1:
* Transpile es2015 features missing (`transform-es2015-classes` is used because computed prototype methods are not supported, but ideally we should only transpile such methods)
* Add polyfills for `fetch` and `URLSearchParams`
* Use `URLSearchParams` as a standalone class, not as a property of an instance of a `URL` object

I haven't noticed anything wrong with the app but we should probably run the test suites on a device too.

@azasypkin Can you review it when you have time?